### PR TITLE
Add -emulate-8-gpu option

### DIFF
--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -188,7 +188,7 @@ class DLRM_Net(nn.Module):
             self.loss_threshold = loss_threshold
             self.emulate_8_gpu = emulate_8_gpu
             # create operators
-            self.emb_l = self.create_emb(m_spa, ln_emb)
+            self.emb_l = []
             self.bot_l = self.create_mlp(ln_bot, sigmoid_bot, use_bias=use_bias_in_linear)
             self.top_l = self.create_mlp(ln_top, sigmoid_top, use_bias=use_bias_in_linear)
 
@@ -819,9 +819,9 @@ if __name__ == "__main__":
         if wj >= args.num_warmup_iters:
             break
         #forward pass
-        Z = dlrm_wrap(X, lS_o, lS_i, use_gpu, device)
+        Z = dlrm_wrap(X, lS_o, lS_i, use_gpu, device, dlrm.ndevices)
         #loss
-        E = loss_fn_wrap(Z, T, use_gpu, device)
+        E = loss_fn_wrap(Z, T, use_gpu, device, dlrm.ndevices)
         #backward pass
         if not args.inference_only:
             optimizer.zero_grad()

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -162,6 +162,7 @@ class DLRM_Net(nn.Module):
         sync_dense_params=True,
         loss_threshold=0.0,
         ndevices=-1,
+        emulate_8_gpu=False,
     ):
         super(DLRM_Net, self).__init__()
 
@@ -182,6 +183,7 @@ class DLRM_Net(nn.Module):
             self.arch_interaction_itself = arch_interaction_itself
             self.sync_dense_params = sync_dense_params
             self.loss_threshold = loss_threshold
+            self.emulate_8_gpu = emulate_8_gpu
             # create operators
             self.emb_l = []
             self.bot_l = self.create_mlp(ln_bot, sigmoid_bot)
@@ -254,7 +256,7 @@ class DLRM_Net(nn.Module):
         return R
 
     def forward(self, dense_x, lS_o, lS_i):
-        if self.ndevices <= 1:
+        if self.ndevices <= 1 and not self.emulate_8_gpu:
             return self.sequential_forward(dense_x, lS_o, lS_i)
         else:
             return self.parallel_forward(dense_x, lS_o, lS_i)
@@ -307,7 +309,11 @@ class DLRM_Net(nn.Module):
         ### prepare input (overwrite) ###
         # scatter dense features (data parallelism)
         # print(dense_x.device)
-        dense_x = scatter(dense_x, device_ids, dim=0)
+        if not self.emulate_8_gpu:
+            dense_x = scatter(dense_x, device_ids, dim=0)
+        else:
+            dense_x = scatter(dense_x[:int(ndevices * dense_x.size(0)/8)], device_ids, dim=0)
+
         # distribute sparse features (model parallelism)
         if (len(self.emb_l) != len(lS_o)) or (len(self.emb_l) != len(lS_i)):
             sys.exit("ERROR: corrupted model input detected in parallel_forward call")
@@ -340,7 +346,10 @@ class DLRM_Net(nn.Module):
         t_list = []
         for k, _ in enumerate(self.emb_l):
             d = torch.device("cuda:" + str(k % ndevices))
-            y = scatter(ly[k], device_ids, dim=0)
+            if not self.emulate_8_gpu:
+                y = scatter(ly[k], device_ids, dim=0)
+            else:
+                y = scatter(ly[k][:int(ndevices * ly[k].size(0)/8)], device_ids, dim=0)
             t_list.append(y)
         # adjust the list to be ordered per device
         ly = list(map(lambda y: list(y), zip(*t_list)))
@@ -430,6 +439,7 @@ if __name__ == "__main__":
     parser.add_argument("--save-onnx", action="store_true", default=False)
     # gpu
     parser.add_argument("--use-gpu", action="store_true", default=False)
+    parser.add_argument("--emulate-8-gpu", action="store_true", default=False)
     # debugging and profiling
     parser.add_argument("--print-freq", type=int, default=1)
     parser.add_argument("--test-freq", type=int, default=-1)
@@ -454,7 +464,11 @@ if __name__ == "__main__":
         torch.backends.cudnn.deterministic = True
         device = torch.device("cuda", 0)
         ngpus = torch.cuda.device_count()  # 1
-        print("Using {} GPU(s)...".format(ngpus))
+        if args.emulate_8_gpu:
+            extra = "(Emulating 8 GPU run)"
+        else:
+            extra = ""
+        print("Using {} GPU(s) {} ...".format(ngpus, extra))
     else:
         device = torch.device("cpu")
         print("Using CPU...")
@@ -547,6 +561,8 @@ if __name__ == "__main__":
                 return list_of_tuples[0]
 
         ln_emb = np.fromstring(args.arch_embedding_size, dtype=int, sep="-")
+        if args.emulate_8_gpu:
+            ln_emb = ln_emb[:int(ngpus * ln_emb.size/8)]
         m_den = ln_bot[0]
         train_data = dp.RandomDataset(
             m_den,
@@ -687,6 +703,7 @@ if __name__ == "__main__":
         sigmoid_top=ln_top.size - 2,
         sync_dense_params=args.sync_dense_params,
         loss_threshold=args.loss_threshold,
+        emulate_8_gpu=args.emulate_8_gpu,
     )
     # test prints
     if args.debug_mode:
@@ -696,7 +713,7 @@ if __name__ == "__main__":
         # print(dlrm)
 
     if use_gpu:
-        if ngpus > 1:
+        if ngpus > 1 or args.emulate_8_gpu:
             # Custom Model-Data Parallel
             # the mlps are replicated and use data parallelism, while
             # the embeddings are distributed and use model parallelism
@@ -734,11 +751,12 @@ if __name__ == "__main__":
         else:
             return dlrm(X, lS_o, lS_i)
 
-    def loss_fn_wrap(Z, T, use_gpu, device):
+    def loss_fn_wrap(Z, T, use_gpu, device, ndevices):
         if use_gpu:
-            return loss_fn(Z, T.to(device))
-        else:
-            return loss_fn(Z, T)
+            if not args.emulate_8_gpu:
+                return loss_fn(Z, T.to(device))
+            else:
+                return loss_fn(Z, T.to(device)[:int(ndevices * T.size(0)/8)])
 
     # training or inference
     best_gA_test = 0
@@ -806,7 +824,7 @@ if __name__ == "__main__":
                 Z = dlrm_wrap(X, lS_o, lS_i, use_gpu, device, dlrm.ndevices)
 
                 # loss
-                E = loss_fn_wrap(Z, T, use_gpu, device)
+                E = loss_fn_wrap(Z, T, use_gpu, device, dlrm.ndevices)
                 '''
                 # debug prints
                 print("output and loss")
@@ -816,7 +834,10 @@ if __name__ == "__main__":
                 # compute loss and accuracy
                 L = E.detach().cpu().numpy()  # numpy array
                 S = Z.detach().cpu().numpy()  # numpy array
-                T = T.detach().cpu().numpy()  # numpy array
+                if not args.emulate_8_gpu:
+                    T = T.detach().cpu().numpy()  # numpy array
+                else:
+                    T = T[:int(dlrm.ndevices * T.size(0)/8)].detach().cpu().numpy()  # numpy array
                 mbs = T.shape[0]  # = args.mini_batch_size except maybe for last
                 A = np.sum((np.round(S, 0) == T).astype(np.uint8)) / mbs
 
@@ -886,12 +907,15 @@ if __name__ == "__main__":
                             X_test, lS_o_test, lS_i_test, use_gpu, device, dlrm.ndevices
                         )
                         # loss
-                        E_test = loss_fn_wrap(Z_test, T_test, use_gpu, device)
+                        E_test = loss_fn_wrap(Z_test, T_test, use_gpu, device, dlrm.ndevices)
 
                         # compute loss and accuracy
                         L_test = E_test.detach().cpu().numpy()  # numpy array
                         S_test = Z_test.detach().cpu().numpy()  # numpy array
-                        T_test = T_test.detach().cpu().numpy()  # numpy array
+                        if not args.emulate_8_gpu:
+                            T_test = T_test.detach().cpu().numpy()  # numpy array
+                        else:
+                            T_test = T_test[:int(dlrm.ndevices * T_test.size(0)/8)].detach().cpu().numpy()  # numpy array
                         mbs_test = T_test.shape[
                             0
                         ]  # = args.mini_batch_size except maybe for last

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -757,6 +757,8 @@ if __name__ == "__main__":
                 return loss_fn(Z, T.to(device))
             else:
                 return loss_fn(Z, T.to(device)[:int(ndevices * T.size(0)/8)])
+        else:
+            return loss_fn(Z, T)
 
     # training or inference
     best_gA_test = 0

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -125,7 +125,7 @@ class DLRM_Net(nn.Module):
         # approach 2: use Sequential container to wrap all layers
         return torch.nn.Sequential(*layers)
 
-    def create_emb(self, m, ln):
+    def create_emb(self, m, ln, ndevices):
         emb_l = nn.ModuleList()
         for i in range(0, ln.size):
             n = ln[i]
@@ -143,7 +143,9 @@ class DLRM_Net(nn.Module):
             # EE.weight.data.copy_(torch.tensor(W))
             # approach 3
             # EE.weight = Parameter(torch.tensor(W),requires_grad=True)
-            emb_l.append(EE)
+            d = torch.device("cuda:" + str(i % ndevices))
+
+            emb_l.append(EE.to(d))
 
         return emb_l
 
@@ -181,7 +183,8 @@ class DLRM_Net(nn.Module):
             self.sync_dense_params = sync_dense_params
             self.loss_threshold = loss_threshold
             # create operators
-            self.emb_l = self.create_emb(m_spa, ln_emb)
+            #self.emb_l = self.create_emb(m_spa, ln_emb)
+            self.emb_l = []
             self.bot_l = self.create_mlp(ln_bot, sigmoid_bot)
             self.top_l = self.create_mlp(ln_top, sigmoid_top)
 
@@ -299,13 +302,13 @@ class DLRM_Net(nn.Module):
             # replicate mlp (data parallelism)
             self.bot_l_replicas = replicate(self.bot_l, device_ids)
             self.top_l_replicas = replicate(self.top_l, device_ids)
-            # distribute embeddings (model parallelism)
-            t_list = []
-            for k, emb in enumerate(self.emb_l):
-                d = torch.device("cuda:" + str(k % ndevices))
-                emb.to(d)
-                t_list.append(emb.to(d))
-            self.emb_l = nn.ModuleList(t_list)
+            ## distribute embeddings (model parallelism)
+            #t_list = []
+            #for k, emb in enumerate(self.emb_l):
+            #    d = torch.device("cuda:" + str(k % ndevices))
+            #    emb.to(d)
+            #    t_list.append(emb.to(d))
+            #self.emb_l = nn.ModuleList(t_list)
             self.parallel_model_batch_size = batch_size
             self.parallel_model_is_not_prepared = False
 
@@ -317,14 +320,14 @@ class DLRM_Net(nn.Module):
         if (len(self.emb_l) != len(lS_o)) or (len(self.emb_l) != len(lS_i)):
             sys.exit("ERROR: corrupted model input detected in parallel_forward call")
 
-        t_list = []
-        i_list = []
-        for k, _ in enumerate(self.emb_l):
-            d = torch.device("cuda:" + str(k % ndevices))
-            t_list.append(lS_o[k].to(d))
-            i_list.append(lS_i[k].to(d))
-        lS_o = t_list
-        lS_i = i_list
+        #t_list = []
+        #i_list = []
+        #for k, _ in enumerate(self.emb_l):
+        #    d = torch.device("cuda:" + str(k % ndevices))
+        #    t_list.append(lS_o[k].to(d))
+        #    i_list.append(lS_i[k].to(d))
+        #lS_o = t_list
+        #lS_i = i_list
 
         ### compute results in parallel ###
         # bottom mlp
@@ -717,6 +720,9 @@ if __name__ == "__main__":
             dlrm.ndevices = min(ngpus, args.mini_batch_size, num_fea - 1)
         dlrm = dlrm.to(device)  # .cuda()
 
+        #Add logic to allocate embedding tables on each device
+        dlrm.emb_l = dlrm.create_emb(m_spa, ln_emb, dlrm.ndevices)
+  
     # specify the loss function
     if args.loss_function == "mse":
         loss_fn = torch.nn.MSELoss(reduction="mean")
@@ -735,12 +741,12 @@ if __name__ == "__main__":
             torch.cuda.synchronize()
         return time.time()
 
-    def dlrm_wrap(X, lS_o, lS_i, use_gpu, device):
+    def dlrm_wrap(X, lS_o, lS_i, use_gpu, device, ndevices):
         if use_gpu:  # .cuda()
             return dlrm(
                 X.to(device),
-                [S_o.to(device) for S_o in lS_o],
-                [S_i.to(device) for S_i in lS_i],
+                [S_o.to(i % ndevices) for i,S_o in enumerate(lS_o)],
+                [S_i.to(i % ndevices) for i,S_i in enumerate(lS_i)],
             )
         else:
             return dlrm(X, lS_o, lS_i)
@@ -814,7 +820,7 @@ if __name__ == "__main__":
                 t1 = time_wrap(use_gpu)
 
                 # forward pass
-                Z = dlrm_wrap(X, lS_o, lS_i, use_gpu, device)
+                Z = dlrm_wrap(X, lS_o, lS_i, use_gpu, device, dlrm.ndevices)
 
                 # loss
                 E = loss_fn_wrap(Z, T, use_gpu, device)
@@ -894,7 +900,7 @@ if __name__ == "__main__":
 
                         # forward pass
                         Z_test = dlrm_wrap(
-                            X_test, lS_o_test, lS_i_test, use_gpu, device
+                            X_test, lS_o_test, lS_i_test, use_gpu, device, dlrm.ndevices
                         )
                         # loss
                         E_test = loss_fn_wrap(Z_test, T_test, use_gpu, device)

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -183,7 +183,6 @@ class DLRM_Net(nn.Module):
             self.sync_dense_params = sync_dense_params
             self.loss_threshold = loss_threshold
             # create operators
-            #self.emb_l = self.create_emb(m_spa, ln_emb)
             self.emb_l = []
             self.bot_l = self.create_mlp(ln_bot, sigmoid_bot)
             self.top_l = self.create_mlp(ln_top, sigmoid_top)
@@ -302,13 +301,6 @@ class DLRM_Net(nn.Module):
             # replicate mlp (data parallelism)
             self.bot_l_replicas = replicate(self.bot_l, device_ids)
             self.top_l_replicas = replicate(self.top_l, device_ids)
-            ## distribute embeddings (model parallelism)
-            #t_list = []
-            #for k, emb in enumerate(self.emb_l):
-            #    d = torch.device("cuda:" + str(k % ndevices))
-            #    emb.to(d)
-            #    t_list.append(emb.to(d))
-            #self.emb_l = nn.ModuleList(t_list)
             self.parallel_model_batch_size = batch_size
             self.parallel_model_is_not_prepared = False
 
@@ -319,15 +311,6 @@ class DLRM_Net(nn.Module):
         # distribute sparse features (model parallelism)
         if (len(self.emb_l) != len(lS_o)) or (len(self.emb_l) != len(lS_i)):
             sys.exit("ERROR: corrupted model input detected in parallel_forward call")
-
-        #t_list = []
-        #i_list = []
-        #for k, _ in enumerate(self.emb_l):
-        #    d = torch.device("cuda:" + str(k % ndevices))
-        #    t_list.append(lS_o[k].to(d))
-        #    i_list.append(lS_i[k].to(d))
-        #lS_o = t_list
-        #lS_i = i_list
 
         ### compute results in parallel ###
         # bottom mlp


### PR DESCRIPTION
Add --emulate-8-gpu option to run on fewer GPUs as if it were part of an 8-GPU run i.e. keep the 'work done per GPU' almost same*** as in an 8-GPU run. This means keeping the number of embedding lookups per table and mb_per_GPU same as that for an 8-GPU run. This allows us to measure weak scaling effects.

***It won't be exactly the same because the number of interactions between bottom MLPs and embedding lookups will change as nGPUs (and hence total n_embedding_tables) increase, since:
`num_int = (num_fea * (num_fea - 1)) // 2 + m_den_out`, where `num_fea = ln_emb.size + 1  # num sparse + num dense features`.
https://github.com/ROCmSoftwarePlatform/dlrm/blob/master/dlrm_s_pytorch.py#L608
This in turn also affects the size of the input to the top MLP.
